### PR TITLE
Abstract output dtype

### DIFF
--- a/examples/verifiable_mnist/verifiable_mnist.ipynb
+++ b/examples/verifiable_mnist/verifiable_mnist.ipynb
@@ -42,29 +42,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "https://api-dev.gizatech.xyz\n"
-     ]
-    }
-   ],
-   "source": [
-    "# TODO: remove this cell when it deploys on main branch\n",
-    "\n",
-    "import os\n",
-    "import uuid\n",
-    "\n",
-    "os.environ['GIZA_API_HOST'] = 'https://api-dev.gizatech.xyz'\n",
-    "print(os.environ['GIZA_API_HOST'])\n"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1980,6 +1957,54 @@
    "metadata": {},
    "source": [
     "Now, let's make a prediction with the Cairo model (`veriable=True`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[<onnxruntime.capi.onnxruntime_pybind11_state.NodeArg object at 0x2cbbebd70>]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.optim as optim\n",
+    "import torchvision\n",
+    "import numpy as np\n",
+    "import logging\n",
+    "from scipy.ndimage import zoom\n",
+    "from giza_actions.action import action, Action\n",
+    "from giza_actions.task import task\n",
+    "from torch.utils.data import DataLoader, TensorDataset\n",
+    "from giza_actions.model import GizaModel\n",
+    "\n",
+    "MODEL_ID = 296  # Update with your model ID\n",
+    "VERSION_ID = 1  # Update with your version ID\n",
+    "\n",
+    "def prediction(model_id, version_id):\n",
+    "    model = GizaModel(id=model_id, version=version_id)\n",
+    "\n",
+    "    print(model.session.get_outputs())\n",
+    "\n",
+    "    # (result, request_id) = model.predict(\n",
+    "    #     input_feed={\"image\": image}, verifiable=True, output_dtype=\"Tensor<FP16x16>\"\n",
+    "    # )\n",
+    "\n",
+    "    # # Convert result to a PyTorch tensor\n",
+    "    # probabilities = torch.tensor(result)\n",
+    "    # # Use argmax to get the predicted class\n",
+    "    # predicted_class = torch.argmax(probabilities, dim=1)\n",
+    "\n",
+    "    # return predicted_class, request_id\n",
+    "\n",
+    "prediction(MODEL_ID, VERSION_ID)"
    ]
   },
   {

--- a/examples/verifiable_mnist/verifiable_mnist.ipynb
+++ b/examples/verifiable_mnist/verifiable_mnist.ipynb
@@ -1961,72 +1961,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "Unable to load from type '<class 'NoneType'>'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[1], line 27\u001b[0m\n\u001b[1;32m     23\u001b[0m     onnx_model \u001b[38;5;241m=\u001b[39m onnx\u001b[38;5;241m.\u001b[39mload(onnx_model)\n\u001b[1;32m     25\u001b[0m     \u001b[38;5;28mprint\u001b[39m(onnx_model)\n\u001b[0;32m---> 27\u001b[0m \u001b[43mprediction\u001b[49m\u001b[43m(\u001b[49m\u001b[43mMODEL_ID\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mVERSION_ID\u001b[49m\u001b[43m)\u001b[49m\n",
-      "Cell \u001b[0;32mIn[1], line 19\u001b[0m, in \u001b[0;36mprediction\u001b[0;34m(model_id, version_id)\u001b[0m\n\u001b[1;32m     18\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mprediction\u001b[39m(model_id, version_id):\n\u001b[0;32m---> 19\u001b[0m     model \u001b[38;5;241m=\u001b[39m \u001b[43mGizaModel\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mid\u001b[39;49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmodel_id\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mversion\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mversion_id\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     21\u001b[0m     onnx_model \u001b[38;5;241m=\u001b[39m model\u001b[38;5;241m.\u001b[39monnx_model\n\u001b[1;32m     23\u001b[0m     onnx_model \u001b[38;5;241m=\u001b[39m onnx\u001b[38;5;241m.\u001b[39mload(onnx_model)\n",
-      "File \u001b[0;32m~/Desktop/Orion-Giza/Tools/actions-sdk/giza_actions/model.py:78\u001b[0m, in \u001b[0;36mGizaModel.__init__\u001b[0;34m(self, model_path, id, version, output_path)\u001b[0m\n\u001b[1;32m     76\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mversion \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_get_version(\u001b[38;5;28mid\u001b[39m, version)\n\u001b[1;32m     77\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39monnx_model \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m---> 78\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39msession \u001b[38;5;241m=\u001b[39m \u001b[43mort\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mInferenceSession\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m     79\u001b[0m \u001b[43m    \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_download_model\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mid\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43moutput_path\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     80\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     81\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mframework \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mversion\u001b[38;5;241m.\u001b[39mframework\n\u001b[1;32m     82\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39muri \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_retrieve_uri(\u001b[38;5;28mid\u001b[39m, version)\n",
-      "File \u001b[0;32m~/Library/Caches/pypoetry/virtualenvs/giza-actions-mYf3m_Lk-py3.11/lib/python3.11/site-packages/onnxruntime/capi/onnxruntime_inference_collection.py:405\u001b[0m, in \u001b[0;36mInferenceSession.__init__\u001b[0;34m(self, path_or_bytes, sess_options, providers, provider_options, **kwargs)\u001b[0m\n\u001b[1;32m    403\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_model_bytes \u001b[38;5;241m=\u001b[39m path_or_bytes  \u001b[38;5;66;03m# TODO: This is bad as we're holding the memory indefinitely\u001b[39;00m\n\u001b[1;32m    404\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m--> 405\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnable to load from type \u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mtype\u001b[39m(path_or_bytes)\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    407\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_sess_options \u001b[38;5;241m=\u001b[39m sess_options\n\u001b[1;32m    408\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_sess_options_initial \u001b[38;5;241m=\u001b[39m sess_options\n",
-      "\u001b[0;31mTypeError\u001b[0m: Unable to load from type '<class 'NoneType'>'"
-     ]
-    }
-   ],
-   "source": [
-    "import torch\n",
-    "import torch.nn as nn\n",
-    "import torch.optim as optim\n",
-    "import torchvision\n",
-    "import numpy as np\n",
-    "import logging\n",
-    "from scipy.ndimage import zoom\n",
-    "from giza_actions.action import action, Action\n",
-    "from giza_actions.task import task\n",
-    "from torch.utils.data import DataLoader, TensorDataset\n",
-    "from giza_actions.model import GizaModel\n",
-    "import onnx\n",
-    "\n",
-    "\n",
-    "MODEL_ID = 296  # Update with your model ID\n",
-    "VERSION_ID = 1  # Update with your version ID\n",
-    "\n",
-    "def prediction(model_id, version_id):\n",
-    "    model = GizaModel(id=model_id, version=version_id)\n",
-    "\n",
-    "    onnx_model = model.onnx_model\n",
-    "\n",
-    "    onnx_model = onnx.load(onnx_model)\n",
-    "    \n",
-    "    print(onnx_model)\n",
-    "\n",
-    "prediction(MODEL_ID, VERSION_ID)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/raphaeldoukhan/Library/Caches/pypoetry/virtualenvs/giza-actions-mYf3m_Lk-py3.11/lib/python3.11/site-packages/prefect/tasks.py:337: UserWarning: A task named 'Preprocess Image' and defined at '/Users/raphaeldoukhan/Desktop/Orion-Giza/Tools/actions-sdk/giza_actions/task.py:7' conflicts with another task. Consider specifying a unique `name` parameter in the task definition:\n",
+      "/Users/raphaeldoukhan/Library/Caches/pypoetry/virtualenvs/giza-actions-mYf3m_Lk-py3.11/lib/python3.11/site-packages/prefect/tasks.py:332: UserWarning: A task named 'Preprocess Image' and defined at '/Users/raphaeldoukhan/Desktop/Orion-Giza/Tools/actions-sdk/giza_actions/task.py:7' conflicts with another task. Consider specifying a unique `name` parameter in the task definition:\n",
       "\n",
       " `@task(name='my_unique_name', ...)`\n",
       "  warnings.warn(\n",
-      "/Users/raphaeldoukhan/Library/Caches/pypoetry/virtualenvs/giza-actions-mYf3m_Lk-py3.11/lib/python3.11/site-packages/prefect/tasks.py:337: UserWarning: A task named 'Prediction with Cairo' and defined at '/Users/raphaeldoukhan/Desktop/Orion-Giza/Tools/actions-sdk/giza_actions/task.py:20' conflicts with another task. Consider specifying a unique `name` parameter in the task definition:\n",
+      "/Users/raphaeldoukhan/Library/Caches/pypoetry/virtualenvs/giza-actions-mYf3m_Lk-py3.11/lib/python3.11/site-packages/prefect/tasks.py:332: UserWarning: A task named 'Prediction with Cairo' and defined at '/Users/raphaeldoukhan/Desktop/Orion-Giza/Tools/actions-sdk/giza_actions/task.py:20' conflicts with another task. Consider specifying a unique `name` parameter in the task definition:\n",
       "\n",
       " `@task(name='my_unique_name', ...)`\n",
       "  warnings.warn(\n",
-      "/Users/raphaeldoukhan/Library/Caches/pypoetry/virtualenvs/giza-actions-mYf3m_Lk-py3.11/lib/python3.11/site-packages/prefect/flows.py:337: UserWarning: A flow named 'Execution: Prediction with Cairo' and defined at '/Users/raphaeldoukhan/Desktop/Orion-Giza/Tools/actions-sdk/giza_actions/action.py:36' conflicts with another flow. Consider specifying a unique `name` parameter in the flow definition:\n",
+      "/Users/raphaeldoukhan/Library/Caches/pypoetry/virtualenvs/giza-actions-mYf3m_Lk-py3.11/lib/python3.11/site-packages/prefect/flows.py:336: UserWarning: A flow named 'Execution: Prediction with Cairo' and defined at '/Users/raphaeldoukhan/Desktop/Orion-Giza/Tools/actions-sdk/giza_actions/action.py:36' conflicts with another flow. Consider specifying a unique `name` parameter in the flow definition:\n",
       "\n",
       " `@flow(name='my_unique_name', ...)`\n",
       "  warnings.warn(\n"
@@ -2035,11 +1985,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">11:08:42.535 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Created flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'industrious-wrasse'</span> for flow<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> 'Execution: Prediction with Cairo'</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:29:27.522 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Created flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'shapeless-snail'</span> for flow<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> 'Execution: Prediction with Cairo'</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "11:08:42.535 | \u001b[36mINFO\u001b[0m    | Created flow run\u001b[35m 'industrious-wrasse'\u001b[0m for flow\u001b[1;35m 'Execution: Prediction with Cairo'\u001b[0m\n"
+       "18:29:27.522 | \u001b[36mINFO\u001b[0m    | Created flow run\u001b[35m 'shapeless-snail'\u001b[0m for flow\u001b[1;35m 'Execution: Prediction with Cairo'\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -2048,11 +1998,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">11:08:42.537 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Action run 'industrious-wrasse' - View at <span style=\"color: #0000ff; text-decoration-color: #0000ff\">https://actions-server-raphael-doukhan-dblzzhtf5q-ew.a.run.app/flow-runs/flow-run/40572d39-7a1f-46be-873f-4737742bff89</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:29:27.523 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Action run 'shapeless-snail' - View at <span style=\"color: #0000ff; text-decoration-color: #0000ff\">https://actions-server-raphael-doukhan-dblzzhtf5q-ew.a.run.app/flow-runs/flow-run/5068c561-0a8c-4fcf-9bff-8cb7b2617d19</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "11:08:42.537 | \u001b[36mINFO\u001b[0m    | Action run 'industrious-wrasse' - View at \u001b[94mhttps://actions-server-raphael-doukhan-dblzzhtf5q-ew.a.run.app/flow-runs/flow-run/40572d39-7a1f-46be-873f-4737742bff89\u001b[0m\n"
+       "18:29:27.523 | \u001b[36mINFO\u001b[0m    | Action run 'shapeless-snail' - View at \u001b[94mhttps://actions-server-raphael-doukhan-dblzzhtf5q-ew.a.run.app/flow-runs/flow-run/5068c561-0a8c-4fcf-9bff-8cb7b2617d19\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -2061,11 +2011,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">11:08:43.118 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Action run 'industrious-wrasse' - Created task run 'Preprocess Image-0' for task 'Preprocess Image'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:29:27.740 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Action run 'shapeless-snail' - Created task run 'Preprocess Image-0' for task 'Preprocess Image'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "11:08:43.118 | \u001b[36mINFO\u001b[0m    | Action run 'industrious-wrasse' - Created task run 'Preprocess Image-0' for task 'Preprocess Image'\n"
+       "18:29:27.740 | \u001b[36mINFO\u001b[0m    | Action run 'shapeless-snail' - Created task run 'Preprocess Image-0' for task 'Preprocess Image'\n"
       ]
      },
      "metadata": {},
@@ -2074,11 +2024,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">11:08:43.121 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Action run 'industrious-wrasse' - Executing 'Preprocess Image-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:29:27.742 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Action run 'shapeless-snail' - Executing 'Preprocess Image-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "11:08:43.121 | \u001b[36mINFO\u001b[0m    | Action run 'industrious-wrasse' - Executing 'Preprocess Image-0' immediately...\n"
+       "18:29:27.742 | \u001b[36mINFO\u001b[0m    | Action run 'shapeless-snail' - Executing 'Preprocess Image-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -2087,11 +2037,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">11:08:43.632 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'Preprocess Image-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:29:28.006 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'Preprocess Image-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "11:08:43.632 | \u001b[36mINFO\u001b[0m    | Task run 'Preprocess Image-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "18:29:28.006 | \u001b[36mINFO\u001b[0m    | Task run 'Preprocess Image-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -2100,11 +2050,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">11:08:43.749 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Action run 'industrious-wrasse' - Created task run 'Prediction with Cairo-0' for task 'Prediction with Cairo'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:29:28.112 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Action run 'shapeless-snail' - Created task run 'Prediction with Cairo-0' for task 'Prediction with Cairo'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "11:08:43.749 | \u001b[36mINFO\u001b[0m    | Action run 'industrious-wrasse' - Created task run 'Prediction with Cairo-0' for task 'Prediction with Cairo'\n"
+       "18:29:28.112 | \u001b[36mINFO\u001b[0m    | Action run 'shapeless-snail' - Created task run 'Prediction with Cairo-0' for task 'Prediction with Cairo'\n"
       ]
      },
      "metadata": {},
@@ -2113,11 +2063,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">11:08:43.751 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Action run 'industrious-wrasse' - Executing 'Prediction with Cairo-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:29:28.115 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Action run 'shapeless-snail' - Executing 'Prediction with Cairo-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "11:08:43.751 | \u001b[36mINFO\u001b[0m    | Action run 'industrious-wrasse' - Executing 'Prediction with Cairo-0' immediately...\n"
+       "18:29:28.115 | \u001b[36mINFO\u001b[0m    | Action run 'shapeless-snail' - Executing 'Prediction with Cairo-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -2134,11 +2084,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">11:08:47.958 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'Prediction with Cairo-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:29:32.420 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'Prediction with Cairo-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "11:08:47.958 | \u001b[36mINFO\u001b[0m    | Task run 'Prediction with Cairo-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "18:29:32.420 | \u001b[36mINFO\u001b[0m    | Task run 'Prediction with Cairo-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -2147,11 +2097,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">11:08:47.961 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Action run 'industrious-wrasse' - Result:  tensor([0])\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:29:32.421 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Action run 'shapeless-snail' - Result:  tensor([0])\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "11:08:47.961 | \u001b[36mINFO\u001b[0m    | Action run 'industrious-wrasse' - Result:  tensor([0])\n"
+       "18:29:32.421 | \u001b[36mINFO\u001b[0m    | Action run 'shapeless-snail' - Result:  tensor([0])\n"
       ]
      },
      "metadata": {},
@@ -2160,11 +2110,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">11:08:47.962 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Action run 'industrious-wrasse' - Request id:  \"cd38a8593d2c429cb8c45f5e37939409\"\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:29:32.422 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Action run 'shapeless-snail' - Request id:  \"b2484bba4b5644df80ab7eed20f1c87b\"\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "11:08:47.962 | \u001b[36mINFO\u001b[0m    | Action run 'industrious-wrasse' - Request id:  \"cd38a8593d2c429cb8c45f5e37939409\"\n"
+       "18:29:32.422 | \u001b[36mINFO\u001b[0m    | Action run 'shapeless-snail' - Request id:  \"b2484bba4b5644df80ab7eed20f1c87b\"\n"
       ]
      },
      "metadata": {},
@@ -2173,11 +2123,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">11:08:48.087 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Action run 'industrious-wrasse' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:29:32.508 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Action run 'shapeless-snail' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "11:08:48.087 | \u001b[36mINFO\u001b[0m    | Action run 'industrious-wrasse' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "18:29:32.508 | \u001b[36mINFO\u001b[0m    | Action run 'shapeless-snail' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -2186,10 +2136,10 @@
     {
      "data": {
       "text/plain": [
-       "(tensor([0]), '\"cd38a8593d2c429cb8c45f5e37939409\"')"
+       "(tensor([0]), '\"b2484bba4b5644df80ab7eed20f1c87b\"')"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2200,6 +2150,7 @@
     "\n",
     "MODEL_ID = 296  # Update with your model ID\n",
     "VERSION_ID = 1  # Update with your version ID\n",
+    "\n",
     "\n",
     "@task(name=f'Preprocess Image')\n",
     "def preprocess_image(image_path):\n",
@@ -2214,12 +2165,13 @@
     "    image = image.reshape(1, 196)  # Reshape to (1, 196) for model input\n",
     "    return image\n",
     "\n",
+    "\n",
     "@task(name=f'Prediction with Cairo')\n",
     "def prediction(image, model_id, version_id):\n",
     "    model = GizaModel(id=model_id, version=version_id)\n",
     "\n",
     "    (result, request_id) = model.predict(\n",
-    "        input_feed={\"image\": image}, verifiable=True, output_dtype=\"Tensor<FP16x16>\"\n",
+    "        input_feed={\"image\": image}, verifiable=True\n",
     "    )\n",
     "\n",
     "    # Convert result to a PyTorch tensor\n",

--- a/examples/verifiable_mnist/verifiable_mnist.ipynb
+++ b/examples/verifiable_mnist/verifiable_mnist.ipynb
@@ -1965,10 +1965,17 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[<onnxruntime.capi.onnxruntime_pybind11_state.NodeArg object at 0x2cbbebd70>]\n"
+     "ename": "TypeError",
+     "evalue": "Unable to load from type '<class 'NoneType'>'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[1], line 27\u001b[0m\n\u001b[1;32m     23\u001b[0m     onnx_model \u001b[38;5;241m=\u001b[39m onnx\u001b[38;5;241m.\u001b[39mload(onnx_model)\n\u001b[1;32m     25\u001b[0m     \u001b[38;5;28mprint\u001b[39m(onnx_model)\n\u001b[0;32m---> 27\u001b[0m \u001b[43mprediction\u001b[49m\u001b[43m(\u001b[49m\u001b[43mMODEL_ID\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mVERSION_ID\u001b[49m\u001b[43m)\u001b[49m\n",
+      "Cell \u001b[0;32mIn[1], line 19\u001b[0m, in \u001b[0;36mprediction\u001b[0;34m(model_id, version_id)\u001b[0m\n\u001b[1;32m     18\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mprediction\u001b[39m(model_id, version_id):\n\u001b[0;32m---> 19\u001b[0m     model \u001b[38;5;241m=\u001b[39m \u001b[43mGizaModel\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mid\u001b[39;49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmodel_id\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mversion\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mversion_id\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     21\u001b[0m     onnx_model \u001b[38;5;241m=\u001b[39m model\u001b[38;5;241m.\u001b[39monnx_model\n\u001b[1;32m     23\u001b[0m     onnx_model \u001b[38;5;241m=\u001b[39m onnx\u001b[38;5;241m.\u001b[39mload(onnx_model)\n",
+      "File \u001b[0;32m~/Desktop/Orion-Giza/Tools/actions-sdk/giza_actions/model.py:78\u001b[0m, in \u001b[0;36mGizaModel.__init__\u001b[0;34m(self, model_path, id, version, output_path)\u001b[0m\n\u001b[1;32m     76\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mversion \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_get_version(\u001b[38;5;28mid\u001b[39m, version)\n\u001b[1;32m     77\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39monnx_model \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m---> 78\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39msession \u001b[38;5;241m=\u001b[39m \u001b[43mort\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mInferenceSession\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m     79\u001b[0m \u001b[43m    \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_download_model\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mid\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43moutput_path\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     80\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     81\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mframework \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mversion\u001b[38;5;241m.\u001b[39mframework\n\u001b[1;32m     82\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39muri \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_retrieve_uri(\u001b[38;5;28mid\u001b[39m, version)\n",
+      "File \u001b[0;32m~/Library/Caches/pypoetry/virtualenvs/giza-actions-mYf3m_Lk-py3.11/lib/python3.11/site-packages/onnxruntime/capi/onnxruntime_inference_collection.py:405\u001b[0m, in \u001b[0;36mInferenceSession.__init__\u001b[0;34m(self, path_or_bytes, sess_options, providers, provider_options, **kwargs)\u001b[0m\n\u001b[1;32m    403\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_model_bytes \u001b[38;5;241m=\u001b[39m path_or_bytes  \u001b[38;5;66;03m# TODO: This is bad as we're holding the memory indefinitely\u001b[39;00m\n\u001b[1;32m    404\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m--> 405\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnable to load from type \u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mtype\u001b[39m(path_or_bytes)\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    407\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_sess_options \u001b[38;5;241m=\u001b[39m sess_options\n\u001b[1;32m    408\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_sess_options_initial \u001b[38;5;241m=\u001b[39m sess_options\n",
+      "\u001b[0;31mTypeError\u001b[0m: Unable to load from type '<class 'NoneType'>'"
      ]
     }
    ],
@@ -1984,6 +1991,8 @@
     "from giza_actions.task import task\n",
     "from torch.utils.data import DataLoader, TensorDataset\n",
     "from giza_actions.model import GizaModel\n",
+    "import onnx\n",
+    "\n",
     "\n",
     "MODEL_ID = 296  # Update with your model ID\n",
     "VERSION_ID = 1  # Update with your version ID\n",
@@ -1991,18 +2000,11 @@
     "def prediction(model_id, version_id):\n",
     "    model = GizaModel(id=model_id, version=version_id)\n",
     "\n",
-    "    print(model.session.get_outputs())\n",
+    "    onnx_model = model.onnx_model\n",
     "\n",
-    "    # (result, request_id) = model.predict(\n",
-    "    #     input_feed={\"image\": image}, verifiable=True, output_dtype=\"Tensor<FP16x16>\"\n",
-    "    # )\n",
-    "\n",
-    "    # # Convert result to a PyTorch tensor\n",
-    "    # probabilities = torch.tensor(result)\n",
-    "    # # Use argmax to get the predicted class\n",
-    "    # predicted_class = torch.argmax(probabilities, dim=1)\n",
-    "\n",
-    "    # return predicted_class, request_id\n",
+    "    onnx_model = onnx.load(onnx_model)\n",
+    "    \n",
+    "    print(onnx_model)\n",
     "\n",
     "prediction(MODEL_ID, VERSION_ID)"
    ]

--- a/giza_actions/model.py
+++ b/giza_actions/model.py
@@ -146,7 +146,8 @@ class GizaModel:
 
             return ort.InferenceSession(onnx_model)
 
-        except:
+        except Exception as e:
+            print(f"Could not download model: {e}")
             return None
 
     def _download_model(self, model_id: int, output_path: str):


### PR DESCRIPTION
Simplify the process for users by automatically determining the output data type of a Cairo model, eliminating the need for manual specification.

This is achieved by identifying the operator type (op_type) responsible for the graph's output. In cases where the op_type corresponds to an "exceptional" operator, the operator's data type is used. Otherwise, the default output type is set to `Tensor<FP16x16>`.